### PR TITLE
Gracefully handle NOSCRIPT for wrapped clients

### DIFF
--- a/redis/goredis/goredis.go
+++ b/redis/goredis/goredis.go
@@ -63,7 +63,7 @@ func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...interface{}) (in
 	}
 
 	v, err := c.delegate.EvalSha(script.Hash, keys, args...).Result()
-	if err != nil && strings.HasPrefix(err.Error(), "NOSCRIPT ") {
+	if err != nil && strings.Contains(err.Error(), "NOSCRIPT ") {
 		v, err = c.delegate.Eval(script.Src, keys, args...).Result()
 	}
 	return v, noErrNil(err)

--- a/redis/goredis/v7/goredis.go
+++ b/redis/goredis/v7/goredis.go
@@ -60,7 +60,7 @@ func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...interface{}) (in
 	}
 
 	v, err := c.delegate.EvalSha(script.Hash, keys, args...).Result()
-	if err != nil && strings.HasPrefix(err.Error(), "NOSCRIPT ") {
+	if err != nil && strings.Contains(err.Error(), "NOSCRIPT ") {
 		v, err = c.delegate.Eval(script.Src, keys, args...).Result()
 	}
 	return v, noErrNil(err)

--- a/redis/goredis/v8/goredis.go
+++ b/redis/goredis/v8/goredis.go
@@ -60,7 +60,7 @@ func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...interface{}) (in
 	}
 
 	v, err := c.delegate.EvalSha(c.ctx, script.Hash, keys, args...).Result()
-	if err != nil && strings.HasPrefix(err.Error(), "NOSCRIPT ") {
+	if err != nil && strings.Contains(err.Error(), "NOSCRIPT ") {
 		v, err = c.delegate.Eval(c.ctx, script.Src, keys, args...).Result()
 	}
 	return v, noErrNil(err)

--- a/redis/redigo/redigo.go
+++ b/redis/redigo/redigo.go
@@ -55,7 +55,7 @@ func (c *conn) PTTL(name string) (time.Duration, error) {
 
 func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...interface{}) (interface{}, error) {
 	v, err := c.delegate.Do("EVALSHA", args(script, script.Hash, keysAndArgs)...)
-	if e, ok := err.(redis.Error); ok && strings.HasPrefix(string(e), "NOSCRIPT ") {
+	if e, ok := err.(redis.Error); ok && strings.Contains(string(e), "NOSCRIPT ") {
 		v, err = c.delegate.Do("EVAL", args(script, script.Src, keysAndArgs)...)
 	}
 	return v, noErrNil(err)


### PR DESCRIPTION
## Summary
We use the `redis.UniversalClient` interface to call `EvalSha`, running the locking script. When this is run for the first time (or after scripts are flushed), redis returns a "NOSCRIPT" error. We handle these cases by checking for the "NOSCRIPT" error and calling `Eval` (thereby loading the script). The aforementioned error is detected by using `errors.HasPrefix("NOSCRIPT ")`, which will fail for clients which modify their error strings with prefixes. We should use `errors.Contains("NOSCRIPT ")` to handle these clients.

## Notes
Determining control flow based upon the content of error strings isn't great, but the go-redis/redis/v8 package doesn't give us a lot of options: it looks as though this functionality is more or less copied from the [go-redis/redis/v8 package](https://github.com/go-redis/redis/blob/master/script.go#L61). 
